### PR TITLE
[Add] クロップ画像の生成時にリサイズを行うコードの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ mask_to_coco
 |   |-- RandAugment.py
 |   |-- crop_dataset.py
 |   |-- crop_image-mask.py
+|   |-- crop_image-mask_resize.py
 |   `-- dataset_mean-std_calc.py
 |-- utils
 |   |-- __init__.py
@@ -154,9 +155,9 @@ optional arguments:
 Settings such as the storage location of the input dataset and the output destination need to be modified in `./config/directory.py`. It is assumed, in essence, that the directory structure (excluding 'masks') follows that in `mask_to_coco.py`.
 
 ### `./tools/crop_image-mask.py`
-画像とマスク画像（各オブジェクトごとに色分けされたマスク画像）のディレクトリからそれぞれのクロップ画像を生成するコード． **花のCT画像に対応するため，特定の処理が入っており，他のデータを扱う際には変更の必要がある．**
+画像とマスク画像（各オブジェクトごとに色分けされたマスク画像）のディレクトリからそれぞれのクロップ画像を生成するコード． 生成されたクロップ画像は指定された画像サイズにリサイズされる．**花のCT画像に対応するため，特定の処理が入っており，他のデータを扱う際には変更の必要がある．**
 
-Code to generate individual cropped images from directories of images and mask images (mask images color-coded for each object). **Specific processing is included to correspond to flower CT images, so modifications may be necessary when working with other data.**
+Code to generate individual cropped images from directories of images and mask images (mask images color-coded for each object). The generated cropped image is resized to the specified image size. **Specific processing is included to correspond to flower CT images, so modifications may be necessary when working with other data.**
 
 ```
 usage: crop_image-mask.py [-h] [-x WIDTH] [-y HEIGHT] [-n NUM] [-t TYPE] input_dir output_dir
@@ -176,6 +177,30 @@ optional arguments:
 基本的には`mask_to_coco.py`でのディレクトリ構造であることを仮定している．
 
 It is assumed, in essence, that the directory structure follows that in `mask_to_coco.py`.
+
+### `./tools/crop_image-mask_resize.py`
+画像とマスク画像（各オブジェクトごとに色分けされたマスク画像）のディレクトリからそれぞれのクロップ画像を生成するコード． **花のCT画像に対応するため，特定の処理が入っており，他のデータを扱う際には変更の必要がある．**
+
+Code to generate individual cropped images from directories of images and mask images (mask images color-coded for each object). **Specific processing is included to correspond to flower CT images, so modifications may be necessary when working with other data.**
+
+```
+usage: crop_image-mask_resize.py [-h] [--crop-x CROP_WIDTH] [--crop-y CROP_HEIGHT] [--resize-x RESIZE_WIDTH] [--resize-y RESIZE_HEIGHT] [-n NUM] [-t TYPE] input_dir output_dir
+
+positional arguments:
+  input_dir             The base directory path of images and masks.
+  output_dir            Storage location for cropped images and masks
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --crop-x CROP_WIDTH   width of the cropped image. Default is 50.
+  --crop-y CROP_HEIGHT  height of the cropped image. Default is 50.
+  --resize-x RESIZE_WIDTH
+                        width after resizing. Default is 150.
+  --resize-y RESIZE_HEIGHT
+                        height after resizing. Default is 150.
+  -n NUM                Number of Crop Image Generations per Image. Default is 10.
+  -t TYPE               train or val or test. Default is train.
+```
 
 
 ### `./tools/dataset_mean-std_calc.py`

--- a/README.md
+++ b/README.md
@@ -155,9 +155,9 @@ optional arguments:
 Settings such as the storage location of the input dataset and the output destination need to be modified in `./config/directory.py`. It is assumed, in essence, that the directory structure (excluding 'masks') follows that in `mask_to_coco.py`.
 
 ### `./tools/crop_image-mask.py`
-画像とマスク画像（各オブジェクトごとに色分けされたマスク画像）のディレクトリからそれぞれのクロップ画像を生成するコード． 生成されたクロップ画像は指定された画像サイズにリサイズされる．**花のCT画像に対応するため，特定の処理が入っており，他のデータを扱う際には変更の必要がある．**
+画像とマスク画像（各オブジェクトごとに色分けされたマスク画像）のディレクトリからそれぞれのクロップ画像を生成するコード． **花のCT画像に対応するため，特定の処理が入っており，他のデータを扱う際には変更の必要がある．**
 
-Code to generate individual cropped images from directories of images and mask images (mask images color-coded for each object). The generated cropped image is resized to the specified image size. **Specific processing is included to correspond to flower CT images, so modifications may be necessary when working with other data.**
+Code to generate individual cropped images from directories of images and mask images (mask images color-coded for each object). **Specific processing is included to correspond to flower CT images, so modifications may be necessary when working with other data.**
 
 ```
 usage: crop_image-mask.py [-h] [-x WIDTH] [-y HEIGHT] [-n NUM] [-t TYPE] input_dir output_dir
@@ -179,9 +179,9 @@ optional arguments:
 It is assumed, in essence, that the directory structure follows that in `mask_to_coco.py`.
 
 ### `./tools/crop_image-mask_resize.py`
-画像とマスク画像（各オブジェクトごとに色分けされたマスク画像）のディレクトリからそれぞれのクロップ画像を生成するコード． **花のCT画像に対応するため，特定の処理が入っており，他のデータを扱う際には変更の必要がある．**
+画像とマスク画像（各オブジェクトごとに色分けされたマスク画像）のディレクトリからそれぞれのクロップ画像を生成するコード． 生成されたクロップ画像は指定された画像サイズにリサイズされる． **花のCT画像に対応するため，特定の処理が入っており，他のデータを扱う際には変更の必要がある．**
 
-Code to generate individual cropped images from directories of images and mask images (mask images color-coded for each object). **Specific processing is included to correspond to flower CT images, so modifications may be necessary when working with other data.**
+Code to generate individual cropped images from directories of images and mask images (mask images color-coded for each object). The generated cropped image is resized to the specified image size. **Specific processing is included to correspond to flower CT images, so modifications may be necessary when working with other data.**
 
 ```
 usage: crop_image-mask_resize.py [-h] [--crop-x CROP_WIDTH] [--crop-y CROP_HEIGHT] [--resize-x RESIZE_WIDTH] [--resize-y RESIZE_HEIGHT] [-n NUM] [-t TYPE] input_dir output_dir
@@ -201,6 +201,10 @@ optional arguments:
   -n NUM                Number of Crop Image Generations per Image. Default is 10.
   -t TYPE               train or val or test. Default is train.
 ```
+
+基本的には`mask_to_coco.py`でのディレクトリ構造であることを仮定している．
+
+It is assumed, in essence, that the directory structure follows that in `mask_to_coco.py`.
 
 
 ### `./tools/dataset_mean-std_calc.py`

--- a/visualization/COCO_Image_Viewer.ipynb
+++ b/visualization/COCO_Image_Viewer.ipynb
@@ -282,8 +282,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "annotation_path = '/workspace/data/flower_dataset/flower_ct_dataset_ORA_Augment_4_10/train_annotations.json'\n",
-    "image_dir = '/workspace/data/flower_dataset/flower_ct_dataset_ORA_Augment_4_10/images/train/'\n",
+    "annotation_path = '/workspace/data/flower_dataset/flower_ct_dataset_ORA_crop_resize/train_annotations.json'\n",
+    "image_dir = '/workspace/data/flower_dataset/flower_ct_dataset_ORA_crop_resize/images/train/'\n",
     "\n",
     "coco_dataset = CocoDataset(annotation_path, image_dir)\n",
     "coco_dataset.display_info()\n",
@@ -300,6 +300,14 @@
     "html = coco_dataset.display_image(20)\n",
     "IPython.display.HTML(html)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "527530a2-555a-4edd-8e08-ad1c37b6f7f5",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
## 更新内容
- クロップ画像の生成時にリサイズを行うコードの追加（ベースは`tools/crop_image-mask.py`）
- コード追加に伴うREADMEの追記
- `tools/crop_image-mask.py`内のデフォルトクロップサイズの修正（200→150）

## コードの使い方
`tools/`に移動した上で以下のコマンドで実行する．
デフォルトは$`50 \times 50 `$に切り出し，$` 150 \times 150`$にリサイズした画像を10枚ずつ生成するコードとなっている．
```
usage: crop_image-mask_resize.py [-h] [--crop-x CROP_WIDTH] [--crop-y CROP_HEIGHT] [--resize-x RESIZE_WIDTH] [--resize-y RESIZE_HEIGHT] [-n NUM] [-t TYPE] input_dir output_dir

positional arguments:
  input_dir             The base directory path of images and masks.
  output_dir            Storage location for cropped images and masks

optional arguments:
  -h, --help            show this help message and exit
  --crop-x CROP_WIDTH   width of the cropped image. Default is 50.
  --crop-y CROP_HEIGHT  height of the cropped image. Default is 50.
  --resize-x RESIZE_WIDTH
                        width after resizing. Default is 150.
  --resize-y RESIZE_HEIGHT
                        height after resizing. Default is 150.
  -n NUM                Number of Crop Image Generations per Image. Default is 10.
  -t TYPE               train or val or test. Default is train.
```

## 注意点など
花のCT画像に対応したものとなっていることから，別のデータを扱う際には変更が必要．

Close #3