### PR TITLE
[Add] 回転させた画像からクロップ画像を生成するコードの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ mask_to_coco
 |   |-- crop_dataset.py
 |   |-- crop_image-mask.py
 |   |-- crop_image-mask_resize.py
+|   |-- crop_rotate.py
 |   `-- dataset_mean-std_calc.py
 |-- utils
 |   |-- __init__.py
@@ -206,6 +207,32 @@ optional arguments:
 
 It is assumed, in essence, that the directory structure follows that in `mask_to_coco.py`.
 
+### `./tools/crop_rotate.py`
+
+画像とマスク画像（各オブジェクトごとに色分けされたマスク画像）のディレクトリからそれぞれのクロップ画像を生成するコード． このコードは回転させながら横長の長方形のように画像を切り出す．前処理として，指定された回転の中心座標が画像中心となるように平行移動をしている． **花のCT画像に対応するため，特定の処理が入っており，他のデータを扱う際には変更の必要がある．**
+
+Code to generate individual cropped images from directories of images and mask images (mask images color-coded for each object). This code crops the image while rotating it to resemble a landscape-oriented rectangle. As a preprocessing step, it performs a translation to ensure that the specified rotation center coordinates align with the center of the image. **Specific processing is included to correspond to flower CT images, so modifications may be necessary when working with other data.**
+
+```
+usage: crop_rotate.py [-h] [--crop-w WIDTH] [--crop-h HEIGHT] [--step STEP] [--type TYPE] [--rotate-x CENTER_X] [--rotate-y CENTER_Y] input_dir output_dir
+
+positional arguments:
+  input_dir            The base directory path of images and masks.
+  output_dir           Storage location for cropped images and masks
+
+optional arguments:
+  -h, --help           show this help message and exit
+  --crop-w WIDTH       width of the cropped image. Default is 900.
+  --crop-h HEIGHT      height of the cropped image. Default is 25.
+  --step STEP          Number of Crop Image Generations per Image. Default is 10.
+  --type TYPE          train or val or test. Default is train.
+  --rotate-x CENTER_X  X-coordinate of the rotation center. Default is 421.
+  --rotate-y CENTER_Y  Y-coordinate of the rotation center. Default is 435.
+```
+
+基本的には`mask_to_coco.py`でのディレクトリ構造であることを仮定している．
+
+It is assumed, in essence, that the directory structure follows that in `mask_to_coco.py`.
 
 ### `./tools/dataset_mean-std_calc.py`
 

--- a/mask_to_coco_multi_core.py
+++ b/mask_to_coco_multi_core.py
@@ -19,7 +19,7 @@ from concurrent.futures.process import ProcessPoolExecutor
 def get_args():
     # 準備
     parser = argparse.ArgumentParser(
-        description="Creating a COCO-format dataset from mask images for instance segmentation."
+        description="Creating a COCO-format dataset from mask images for instance segmentation （Parallel Version)."
     )
 
     # 標準入力以外の場合

--- a/tools/crop_image-mask.py
+++ b/tools/crop_image-mask.py
@@ -16,7 +16,7 @@ from utils.tools import background_del, assign_cluster_number
 def get_args():
     # 準備
     parser = argparse.ArgumentParser(
-        description="Crop an Existing Dataset (COCO Format) to Generate Mask Images"
+        description="Code to generate individual cropped images from directories of images and mask images (mask images color-coded for each object)"
     )
 
     # 標準入力以外の場合

--- a/tools/crop_image-mask_resize.py
+++ b/tools/crop_image-mask_resize.py
@@ -16,7 +16,7 @@ from utils.tools import background_del, assign_cluster_number
 def get_args():
     # 準備
     parser = argparse.ArgumentParser(
-        description="Crop an Existing Dataset (COCO Format) to Generate Mask Images"
+        description="Code to generate individual cropped images from directories of images and mask images (mask images color-coded for each object)"
     )
 
     # 標準入力以外の場合

--- a/tools/crop_rotate.py
+++ b/tools/crop_rotate.py
@@ -1,0 +1,121 @@
+import json
+import os
+import random
+import numpy as np
+from PIL import Image, ImageDraw
+from tqdm import tqdm
+import cv2
+import glob
+
+import argparse
+import sys
+
+def get_args():
+    # 準備
+    parser = argparse.ArgumentParser(
+        description="Code for cropping an image and a mask image while rotating"
+    )
+
+    # 標準入力以外の場合
+    parser = argparse.ArgumentParser()
+    
+    # クロップ元の画像とマスク画像が含まれているディレクトリの指定
+    parser.add_argument("input_dir", type=str, help="The base directory path of images and masks.")
+    # 出力先のディレクトリの指定
+    parser.add_argument("output_dir", type=str, help="Storage location for cropped images and masks")
+    
+    # クロップサイズを設定
+    parser.add_argument("--crop-w", dest="width", type=int, default=900, help="width of the cropped image. Default is 900.")
+    parser.add_argument("--crop-h", dest="height", type=int, default=25, help="height of the cropped image. Default is 25.")
+    
+    # 画像の回転ステップ
+    parser.add_argument("--step", dest="step", type=int, default=10, help="Number of Crop Image Generations per Image. Default is 10.")
+    
+    # train or val or test
+    parser.add_argument("--type", dest="type", type=str, default='train', help="train or val or test. Default is train.")
+    
+    # 回転中心
+    parser.add_argument("--rotate-x", dest="center_x", type=int, default=421, help="X-coordinate of the rotation center. Default is 421.")
+    parser.add_argument("--rotate-y", dest="center_y", type=int, default=435, help="Y-coordinate of the rotation center. Default is 435.")
+
+    args = parser.parse_args()
+
+    # 引数から画像番号
+    DIR_INPUT   = args.input_dir
+    DIR_OUTPUT  = args.output_dir
+    crop_width  = args.width
+    crop_height = args.height
+    angle_step  = args.step
+    output_type = args.type
+    rotate_x    = args.center_x
+    rotate_y    = args.center_y  
+
+    return DIR_INPUT, DIR_OUTPUT, crop_width, crop_height, angle_step, output_type, rotate_x, rotate_y
+
+def main(DIR_INPUT, DIR_OUTPUT, crop_width, crop_height, angle_step, output_type, rotate_x, rotate_y):
+
+    img_files = glob.glob(os.path.join(DIR_INPUT, "images", output_type, "*"))
+    mask_files = glob.glob(os.path.join(DIR_INPUT, "masks", output_type, "*"))
+
+    img_files.sort()
+    mask_files.sort()
+
+    DIR_CROP_IMAGE = os.path.join(DIR_OUTPUT, "images", output_type)
+    DIR_CROP_MASK  = os.path.join(DIR_OUTPUT, "masks", output_type)
+
+    os.makedirs(DIR_CROP_IMAGE, exist_ok=True)
+    os.makedirs(DIR_CROP_MASK , exist_ok=True)
+
+    with tqdm(range(len(img_files))) as pbar:
+        for file_num in pbar:
+            
+            img_path  = img_files[file_num]
+            mask_path = mask_files[file_num]
+
+            img_name  = os.path.splitext(os.path.basename(img_path))[0]
+            
+            pbar.set_description(f"Process: {img_name}")
+
+            image = (Image.open(img_path)).convert('L')
+            mask  = (Image.open(mask_path)).convert('RGB')
+            
+            center_x, center_y = image.size[0] // 2, image.size[1] // 2
+            center_x_fix, center_y_fix = image.size[0] // 2 - rotate_x, image.size[1] // 2 - rotate_y
+            
+            # 中心座標を花弁の中心に移動
+            image_center = image.rotate(0, translate=(center_x_fix, center_y_fix))
+            mask_center  = mask.rotate(0, translate=(center_x_fix, center_y_fix))
+            
+            # 余白の部分を27〜41のランダムな輝度値で埋める
+            img_center_np = np.array(image_center)
+            zero_positions = np.argwhere(img_center_np == 0)
+            random_values = np.random.randint(27, 41, size=zero_positions.shape[0])
+            img_center_np[zero_positions[:, 0], zero_positions[:, 1]] = random_values
+            
+            image = (Image.fromarray(img_center_np)).convert('L')
+            
+            rect_x = rotate_x - crop_width // 2
+            rect_y = rotate_y - crop_height // 2
+            
+            for angle in range(0, 360, angle_step):
+                rotated_image = image.rotate(angle)
+                rotated_mask  = mask_center.rotate(angle)
+                
+                crop_image = rotated_image.crop((rect_x, rect_y, rect_x + crop_width, rect_y + crop_height))
+                crop_mask  = rotated_mask.crop((rect_x, rect_y, rect_x + crop_width, rect_y + crop_height))
+                
+                crop_image_np = np.array(crop_image)
+                zero_positions = np.argwhere(crop_image_np == 0)
+                random_values = np.random.randint(27, 41, size=zero_positions.shape[0])
+                crop_image_np[zero_positions[:, 0], zero_positions[:, 1]] = random_values
+
+                crop_image = (Image.fromarray(crop_image_np)).convert('L')
+                
+                new_file_name = img_name + f'_{angle:03d}.png'
+                
+                crop_image.save(os.path.join(DIR_CROP_IMAGE, new_file_name))
+                crop_mask.save(os.path.join(DIR_CROP_MASK, new_file_name))
+    
+if __name__ == "__main__":
+    DIR_INPUT, DIR_OUTPUT, crop_width, crop_height, angle_step, output_type, rotate_x, rotate_y = get_args()
+    main(DIR_INPUT, DIR_OUTPUT, crop_width, crop_height, angle_step, output_type, rotate_x, rotate_y)


### PR DESCRIPTION
## 更新内容
- 回転させた画像からクロップ画像を生成するコードの追加
- コード追加に伴うREADMEの追記
- `mask_to_coco_multi_core.py`,`tools/crop_image-mask.py`,`tools/crop_image-mask_resize.py`内のArgmentParserのdescriptionを修正

## コードの使い方
`tools/`に移動した上で以下のコマンドで実行する．
デフォルトは画像を`step`で指定された角度で回転しながら$`900 \times 25 `$の矩形を切り出している．また，`center_x`,`center_y`で指定された座標が回転の中心座標となるように前処理が行われている．
```
usage: crop_rotate.py [-h] [--crop-w WIDTH] [--crop-h HEIGHT] [--step STEP] [--type TYPE] [--rotate-x CENTER_X] [--rotate-y CENTER_Y] input_dir output_dir
positional arguments:
  input_dir            The base directory path of images and masks.
  output_dir           Storage location for cropped images and masks
optional arguments:
  -h, --help           show this help message and exit
  --crop-w WIDTH       width of the cropped image. Default is 900.
  --crop-h HEIGHT      height of the cropped image. Default is 25.
  --step STEP          Number of Crop Image Generations per Image. Default is 10.
  --type TYPE          train or val or test. Default is train.
  --rotate-x CENTER_X  X-coordinate of the rotation center. Default is 421.
  --rotate-y CENTER_Y  Y-coordinate of the rotation center. Default is 435.
```

## 注意点など
花のCT画像に対応したものとなっていることから，別のデータを扱う際には変更が必要．

Close #5